### PR TITLE
Pedantic changes

### DIFF
--- a/javascript-modules.md
+++ b/javascript-modules.md
@@ -282,7 +282,7 @@ There are a few popular bundlers, most of which use Babel as a dependency to com
 * [JSPM](http://jspm.io/) sits on top of npm and [SystemJS](https://github.com/systemjs/systemjs).
 * [Ember CLI](http://ember-cli.com/) is an easy-breezy command line tool similar to webpack for users of Ember. It uses Broccoli under the hood.
 
-Which one should you use? Whichever works best for you. I'm a big fan of Browserify for the ease of getting started and webpack for much of its React integrations. The beauty of writing ES6 modules is that you aren't writing Browserify or webpack modules, you can switch your bundler at any time. There are a lot of opinions out there on what to use, so do a quick search and you'll find plenty of arguments for either side. 
+Which one should you use? Whichever works best for you. I'm a big fan of Browserify for the ease of getting started and webpack for much of its React integrations. The beauty of writing ES6 modules is that you aren't writing Browserify or webpack modules - you can switch your bundler at any time. There are a lot of opinions out there on what to use, so do a quick search and you'll find plenty of arguments for either side. 
 
 If you are already running tasks via Gulp, Grunt or NPM tasks for your existing JavaScript and CSS, integrating this into your workflow is [fairly simple](https://github.com/wesbos/React-For-Beginners-Starter-Files/blob/master/01%20-%20Introduction%20-%20Start%20Here/gulpfile.js#L58-L99). 
 


### PR DESCRIPTION
Might sound better with just one "fewer".

"Examples of default exports may be a single StorePicker React Component or an array of data." is a really weird sentence. 

Changed `var` to `const` for `dogs`, but I guess that's something of an opinion.

"a dozen or two" is a little weird (sounds like "12 or 2", not "12 or 24")

I made a handful of English stylistic changes. I tried not to change the tone or your style, but I found some of the wording a little too awkward so I reworded them. Hope you don't mind. =)
